### PR TITLE
Versioning and documenting the API

### DIFF
--- a/CityInfo/CityInfo.API/CityInfo.API.csproj
+++ b/CityInfo/CityInfo.API/CityInfo.API.csproj
@@ -5,10 +5,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>14721e58-5f2a-464f-9f9e-91b9f38996a5</UserSecretsId>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <DocumentationFile>CityInfo.API.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="8.0.14" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />

--- a/CityInfo/CityInfo.API/CityInfo.API.csproj
+++ b/CityInfo/CityInfo.API/CityInfo.API.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="8.0.14" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />

--- a/CityInfo/CityInfo.API/CityInfo.API.xml
+++ b/CityInfo/CityInfo.API/CityInfo.API.xml
@@ -4,14 +4,64 @@
         <name>CityInfo.API</name>
     </assembly>
     <members>
+        <member name="T:CityInfo.API.Controllers.AuthenticationController.AuthenticationRequestBody">
+            <summary>
+            The credentials provided by the user during the try to establish a secure connection
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Controllers.AuthenticationController.AuthenticationRequestBody.Username">
+            <summary>
+            The username of the user credentials
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Controllers.AuthenticationController.AuthenticationRequestBody.Password">
+            <summary>
+            The pasword of the user credentials
+            </summary>
+        </member>
+        <member name="M:CityInfo.API.Controllers.AuthenticationController.Authenticate(CityInfo.API.Controllers.AuthenticationController.AuthenticationRequestBody)">
+            <summary>
+            Verifies the input credentials defined by the user and returns a JWT token to secure the connection with the API
+            </summary>
+            <param name="authenticationRequestBody">The credentials (username and password) indicated by the user during the connection try</param>
+            <returns>A JWT token to secure the connection with the API</returns>
+            <response code="200">Returns the JWT token for secure connection</response>
+        </member>
+        <member name="M:CityInfo.API.Controllers.CitiesController.GetCities(System.String,System.String,System.Int32,System.Int32)">
+            <summary>
+            Get all cities without their points of interests
+            </summary>
+            <param name="name">The filter that shall be applied in the cities returned, based on their name (optional)</param>
+            <param name="searchQuery">The query that shall be applied in the cities filtered, checking if their name includes that keyword (optional)</param>
+            <param name="pageNumber">The specified page to show in the results, after returning those applicable filtered and queried results</param>
+            <param name="pageSize">The amount of cities that each page can include in the results</param>
+            <returns>All cities without their points of interests</returns>
+            <response code="200">Returns the list with all filtered cities</response>
+        </member>
         <member name="M:CityInfo.API.Controllers.CitiesController.GetCity(System.Int32,System.Boolean)">
             <summary>
-            Get a city by an Id
+            Get a city by an Id, with or without its points of interests
             </summary>
             <param name="id">The Id of the city to get</param>
             <param name="includePointsOfInterest">Whether or not to include the points of interests of the city returned</param>
             <returns>A city with or without its points of interests</returns>
             <response code="200">Returns the requested city</response>
+        </member>
+        <member name="M:CityInfo.API.Controllers.FilesController.GetFile(System.Int32)">
+            <summary>
+            Get a specific file by an Id
+            </summary>
+            <param name="fileId">The Id of the file to be returned</param>
+            <returns>A file (image)</returns>
+            <response code="200">The file (image) with the requested Id</response>
+        </member>
+        <member name="M:CityInfo.API.Controllers.FilesController.CreateFile(Microsoft.AspNetCore.Http.IFormFile)">
+            <summary>
+            Uploads a new file into the server
+            </summary>
+            <param name="file">The new file to be uploaded</param>
+            <returns>A confirmation 200 Status message that the upload was successful</returns>
+            <response code="200">A confirmation message that the new file was successfully uploaded</response>
         </member>
         <member name="M:CityInfo.API.DbContexts.CityInfoContext.OnModelCreating(Microsoft.EntityFrameworkCore.ModelBuilder)">
             <summary>
@@ -72,6 +122,36 @@
         <member name="M:CityInfo.API.Migrations.InitialDataSeed.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
             <inheritdoc />
         </member>
+        <member name="T:CityInfo.API.Models.CityDto">
+            <summary>
+            A city with its points of interests
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.CityDto.Id">
+            <summary>
+            The Id of the city
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.CityDto.Name">
+            <summary>
+            The name of the city
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.CityDto.Description">
+            <summary>
+            The description of the city
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.CityDto.NumberOfPointsOfInterest">
+            <summary>
+            The total points of interests of the city
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.CityDto.PointsOfInterest">
+            <summary>
+            A list with all the points of interests of the city
+            </summary>
+        </member>
         <member name="T:CityInfo.API.Models.CityWithoutPointsOfInterestDto">
             <summary>
             A city without its points of interests
@@ -90,6 +170,56 @@
         <member name="P:CityInfo.API.Models.CityWithoutPointsOfInterestDto.Description">
             <summary>
             The description of the city
+            </summary>
+        </member>
+        <member name="T:CityInfo.API.Models.PointOfInterestDto">
+            <summary>
+            A point of interest of a city
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.PointOfInterestDto.Id">
+            <summary>
+            The Id of the point of interest
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.PointOfInterestDto.Name">
+            <summary>
+            The name of the point of interest
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.PointOfInterestDto.Description">
+            <summary>
+            The description of the point of interest
+            </summary>
+        </member>
+        <member name="T:CityInfo.API.Models.PointOfInterestForCreationDto">
+            <summary>
+            A point of interest of a city (used to create a new one)
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.PointOfInterestForCreationDto.Name">
+            <summary>
+            The name of the new point of interest
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.PointOfInterestForCreationDto.Description">
+            <summary>
+            The description of the new point of interest
+            </summary>
+        </member>
+        <member name="T:CityInfo.API.Models.PointOfInterestForUpdatingDto">
+            <summary>
+            A point of interest of a city (used to update an existing one)
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.PointOfInterestForUpdatingDto.Name">
+            <summary>
+            The updated name of an existing point of interest
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.PointOfInterestForUpdatingDto.Description">
+            <summary>
+            The updated description of an existing point of interest
             </summary>
         </member>
         <member name="T:CityInfo.API.Properties.Resources">

--- a/CityInfo/CityInfo.API/CityInfo.API.xml
+++ b/CityInfo/CityInfo.API/CityInfo.API.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>CityInfo.API</name>
+    </assembly>
+    <members>
+        <member name="M:CityInfo.API.Controllers.CitiesController.GetCity(System.Int32,System.Boolean)">
+            <summary>
+            Get a city by an Id
+            </summary>
+            <param name="id">The Id of the city to get</param>
+            <param name="includePointsOfInterest">Whether or not to include the points of interests of the city returned</param>
+            <returns>A city with or without its points of interests</returns>
+            <response code="200">Returns the requested city</response>
+        </member>
+        <member name="M:CityInfo.API.DbContexts.CityInfoContext.OnModelCreating(Microsoft.EntityFrameworkCore.ModelBuilder)">
+            <summary>
+            1) This allows to manually construct our model, if the conventions we used until
+            now were not sufficient or if we preffered to be more explicit.
+            2) It can also be used to provide data for seeding the database.
+            </summary>
+            <param name="modelBuilder"></param>
+        </member>
+        <member name="M:CityInfo.API.Entities.City.#ctor(System.String)">
+            <summary>
+            By defining this overloaded constructor,
+            we convey to any reader/developer that we
+            always want this 'City' class to have a name
+            </summary>
+        </member>
+        <member name="M:CityInfo.API.Entities.PointOfInterest.#ctor(System.String)">
+            <summary>
+            Similarly here, as we did with 'City' class,
+            by defining this overloaded constructor,
+            we convey to any reader/developer that we always
+            want this 'PointOfInterest' class to have a name
+            </summary>
+        </member>
+        <member name="T:CityInfo.API.Migrations.CityInfoDatabaseInitialMigration">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.CityInfoDatabaseInitialMigration.Up(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.CityInfoDatabaseInitialMigration.Down(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.CityInfoDatabaseInitialMigration.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="T:CityInfo.API.Migrations.CityInfoDatabaseAddPointOfInterestDescription">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.CityInfoDatabaseAddPointOfInterestDescription.Up(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.CityInfoDatabaseAddPointOfInterestDescription.Down(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.CityInfoDatabaseAddPointOfInterestDescription.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="T:CityInfo.API.Migrations.InitialDataSeed">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.InitialDataSeed.Up(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.InitialDataSeed.Down(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:CityInfo.API.Migrations.InitialDataSeed.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="T:CityInfo.API.Models.CityWithoutPointsOfInterestDto">
+            <summary>
+            A city without its points of interests
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.CityWithoutPointsOfInterestDto.Id">
+            <summary>
+            The Id of the city
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.CityWithoutPointsOfInterestDto.Name">
+            <summary>
+            The name of the city
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Models.CityWithoutPointsOfInterestDto.Description">
+            <summary>
+            The description of the city
+            </summary>
+        </member>
+        <member name="T:CityInfo.API.Properties.Resources">
+            <summary>
+              A strongly-typed resource class, for looking up localized strings, etc.
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Properties.Resources.ResourceManager">
+            <summary>
+              Returns the cached ResourceManager instance used by this class.
+            </summary>
+        </member>
+        <member name="P:CityInfo.API.Properties.Resources.Culture">
+            <summary>
+              Overrides the current thread's CurrentUICulture property for all
+              resource lookups using this strongly typed resource class.
+            </summary>
+        </member>
+        <member name="M:CityInfo.API.Services.CloudMailService.Send(System.String,System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:CityInfo.API.Services.ICityInfoRepository.GetCityAsync(System.Int32,System.Boolean)">
+            <summary>
+            NOTE: Explicitly defining here that the returned type is
+            a nullable 'City?' serves two main purposes:
+            1) Explicitly defining that the returned result can be null,
+            so that all developers are aware and handle it appropriately.
+            2) Enables compiler warnings if someone tries to use the returned
+            type directly without checking it is null (safer code practice).
+            </summary>
+            <param name="cityId"></param>
+            <returns></returns>
+        </member>
+        <member name="M:CityInfo.API.Services.LocalMailService.Send(System.String,System.String)">
+            <inheritdoc/>
+        </member>
+    </members>
+</doc>

--- a/CityInfo/CityInfo.API/Controllers/AuthenticationController.cs
+++ b/CityInfo/CityInfo.API/Controllers/AuthenticationController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -7,11 +8,24 @@ namespace CityInfo.API.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [ApiVersion(0.1)]
+    [ApiVersion(1)]
+    [ApiVersion(2)]
     public class AuthenticationController : Controller
     {
+        /// <summary>
+        /// The credentials provided by the user during the try to establish a secure connection
+        /// </summary>
         public class AuthenticationRequestBody
         {
+            /// <summary>
+            /// The username of the user credentials
+            /// </summary>
             public string? Username { get; set; }
+
+            /// <summary>
+            /// The pasword of the user credentials
+            /// </summary>
             public string? Password { get; set; }
         }
 
@@ -35,55 +49,75 @@ namespace CityInfo.API.Controllers
         }
 
         // Private members
+        private readonly ILogger<AuthenticationController> _logger;
         private readonly IConfiguration _configuration;
 
-        public AuthenticationController(IConfiguration configuration)
+        public AuthenticationController(ILogger<AuthenticationController> logger, IConfiguration configuration)
         {
+            _logger = logger;
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
 
+        /// <summary>
+        /// Verifies the input credentials defined by the user and returns a JWT token to secure the connection with the API
+        /// </summary>
+        /// <param name="authenticationRequestBody">The credentials (username and password) indicated by the user during the connection try</param>
+        /// <returns>A JWT token to secure the connection with the API</returns>
+        /// <response code="200">Returns the JWT token for secure connection</response>
         [HttpPost("authenticate")]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public ActionResult<string> Authenticate(AuthenticationRequestBody authenticationRequestBody)
         {
-            // Step 1: Validate the username and the password
-            var user = ValidateUserCredentials(authenticationRequestBody.Username, authenticationRequestBody.Password);
-            if (user == null)
+            try
             {
-                return Unauthorized();
+                // Step 1: Validate the username and the password
+                var user = ValidateUserCredentials(authenticationRequestBody.Username, authenticationRequestBody.Password);
+                if (user == null)
+                {
+                    return Unauthorized();
+                }
+
+                // Step 2: Create a token
+
+                // "Header": The security key is used to generate the signing credentials that will
+                // be used later to generate the token. The "Header" of the generated token includes
+                // those information about what algorithm was used (here the HS256) and the type of it.
+                var securityKey = new SymmetricSecurityKey(Convert.FromBase64String(_configuration["Authentication:SecretForKey"]));
+                var signingCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+                // "Payload": The claims are part of the "Payload" of the token that will be generated
+                // and can include any information we want (sub, given_name, family_name are
+                // conventions that are widely used in the claims, that's why we use them here).
+                var claimsForToken = new List<Claim>();
+                claimsForToken.Add(new Claim("sub", user.UserID.ToString()));
+                claimsForToken.Add(new Claim("given_name", user.FirstName));
+                claimsForToken.Add(new Claim("family_name", user.LastName));
+                claimsForToken.Add(new Claim("city", user.City));
+
+                // Here the toke is generated. The last part of the token, the "Signature"
+                // is added in the end of the token.
+                var jwtSecurityToken = new JwtSecurityToken(
+                    _configuration["Authentication:Issuer"],
+                    _configuration["Authentication:Audience"],
+                    claimsForToken,
+                    DateTime.UtcNow,
+                    DateTime.UtcNow.AddHours(1),
+                    signingCredentials);
+                var tokenToReturn = new JwtSecurityTokenHandler().WriteToken(jwtSecurityToken);
+
+                // IMPORTANT INFO: The tokens are not encrypted but they are only encoded.
+                // That means token-based security relies on HTTPS protocol for encryption.
+                // This is why, when tokens are used, HTTPS is a must-use.
+                return Ok(tokenToReturn);
             }
-
-            // Step 2: Create a token
-            
-            // "Header": The security key is used to generate the signing credentials that will
-            // be used later to generate the token. The "Header" of the generated token includes
-            // those information about what algorithm was used (here the HS256) and the type of it.
-            var securityKey = new SymmetricSecurityKey(Convert.FromBase64String(_configuration["Authentication:SecretForKey"]));
-            var signingCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
-            
-            // "Payload": The claims are part of the "Payload" of the token that will be generated
-            // and can include any information we want (sub, given_name, family_name are
-            // conventions that are widely used in the claims, that's why we use them here).
-            var claimsForToken = new List<Claim>();
-            claimsForToken.Add(new Claim("sub", user.UserID.ToString()));
-            claimsForToken.Add(new Claim("given_name", user.FirstName));
-            claimsForToken.Add(new Claim("family_name", user.LastName));
-            claimsForToken.Add(new Claim("city", user.City));
-
-            // Here the toke is generated. The last part of the token, the "Signature"
-            // is added in the end of the token.
-            var jwtSecurityToken = new JwtSecurityToken(
-                _configuration["Authentication:Issuer"],
-                _configuration["Authentication:Audience"],
-                claimsForToken,
-                DateTime.UtcNow,
-                DateTime.UtcNow.AddHours(1),
-                signingCredentials);
-            var tokenToReturn = new JwtSecurityTokenHandler().WriteToken(jwtSecurityToken);
-
-            // IMPORTANT INFO: The tokens are not encrypted but they are only encoded.
-            // That means token-based security relies on HTTPS protocol for encryption.
-            // This is why, when tokens are used, HTTPS is a must-use.
-            return Ok(tokenToReturn);
+            catch (Exception ex)
+            {
+                _logger.LogCritical("Unexpected exception occurred when trying to verify the credentials.", ex);
+                return StatusCode(500, $"A problem occurred while handling your request.");
+            }
         }
 
         private CityInfoUser ValidateUserCredentials(string? username, string? password)

--- a/CityInfo/CityInfo.API/Controllers/CitiesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/CitiesController.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+﻿using Asp.Versioning;
+using AutoMapper;
 using CityInfo.API.Models;
 using CityInfo.API.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -8,8 +9,10 @@ using System.Text.Json;
 namespace CityInfo.API.Controllers
 {
     [ApiController]
-    [Authorize]
+    //[Authorize]
     [Route("api/[controller]")]
+    [ApiVersion(1)]
+    [ApiVersion(2)]
     public class CitiesController : ControllerBase
     {
         // Private members

--- a/CityInfo/CityInfo.API/Controllers/CitiesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/CitiesController.cs
@@ -28,7 +28,19 @@ namespace CityInfo.API.Controllers
             _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         }
 
+        /// <summary>
+        /// Get all cities without their points of interests
+        /// </summary>
+        /// <param name="name">The filter that shall be applied in the cities returned, based on their name (optional)</param>
+        /// <param name="searchQuery">The query that shall be applied in the cities filtered, checking if their name includes that keyword (optional)</param>
+        /// <param name="pageNumber">The specified page to show in the results, after returning those applicable filtered and queried results</param>
+        /// <param name="pageSize">The amount of cities that each page can include in the results</param>
+        /// <returns>All cities without their points of interests</returns>
+        /// <response code="200">Returns the list with all filtered cities</response>
         [HttpGet()]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<ActionResult<IEnumerable<CityWithoutPointsOfInterestDto>>> GetCities(
             [FromQuery(Name = "namefilter")] string? name,
             string? searchQuery,
@@ -58,7 +70,7 @@ namespace CityInfo.API.Controllers
         }
 
         /// <summary>
-        /// Get a city by an Id
+        /// Get a city by an Id, with or without its points of interests
         /// </summary>
         /// <param name="id">The Id of the city to get</param>
         /// <param name="includePointsOfInterest">Whether or not to include the points of interests of the city returned</param>
@@ -67,6 +79,7 @@ namespace CityInfo.API.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCity(int id, bool includePointsOfInterest = false)
         {

--- a/CityInfo/CityInfo.API/Controllers/CitiesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/CitiesController.cs
@@ -57,7 +57,17 @@ namespace CityInfo.API.Controllers
             }
         }
 
+        /// <summary>
+        /// Get a city by an Id
+        /// </summary>
+        /// <param name="id">The Id of the city to get</param>
+        /// <param name="includePointsOfInterest">Whether or not to include the points of interests of the city returned</param>
+        /// <returns>A city with or without its points of interests</returns>
+        /// <response code="200">Returns the requested city</response>
         [HttpGet("{id}")]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> GetCity(int id, bool includePointsOfInterest = false)
         {
             try

--- a/CityInfo/CityInfo.API/Controllers/CitiesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/CitiesController.cs
@@ -9,7 +9,7 @@ using System.Text.Json;
 namespace CityInfo.API.Controllers
 {
     [ApiController]
-    //[Authorize]
+    [Authorize]
     [Route("api/v{version:apiVersion}/[controller]")]
     [ApiVersion(1)]
     [ApiVersion(2)]

--- a/CityInfo/CityInfo.API/Controllers/CitiesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/CitiesController.cs
@@ -10,7 +10,7 @@ namespace CityInfo.API.Controllers
 {
     [ApiController]
     //[Authorize]
-    [Route("api/[controller]")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [ApiVersion(1)]
     [ApiVersion(2)]
     public class CitiesController : ControllerBase

--- a/CityInfo/CityInfo.API/Controllers/FilesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/FilesController.cs
@@ -8,7 +8,7 @@ namespace CityInfo.API.Controllers
 {
     [ApiController]
     //[Authorize]
-    [Route("api/[controller]")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     public class FilesController : ControllerBase
     {
         // Private members

--- a/CityInfo/CityInfo.API/Controllers/FilesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/FilesController.cs
@@ -1,5 +1,4 @@
 ﻿using Asp.Versioning;
-using CityInfo.API.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
@@ -7,7 +6,7 @@ using Microsoft.AspNetCore.StaticFiles;
 namespace CityInfo.API.Controllers
 {
     [ApiController]
-    //[Authorize]
+    [Authorize]
     [Route("api/v{version:apiVersion}/[controller]")]
     [ApiVersion(1)]
     [ApiVersion(2)]

--- a/CityInfo/CityInfo.API/Controllers/FilesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/FilesController.cs
@@ -9,6 +9,8 @@ namespace CityInfo.API.Controllers
     [ApiController]
     //[Authorize]
     [Route("api/v{version:apiVersion}/[controller]")]
+    [ApiVersion(1)]
+    [ApiVersion(2)]
     public class FilesController : ControllerBase
     {
         // Private members
@@ -27,9 +29,18 @@ namespace CityInfo.API.Controllers
             };
         }
 
+        /// <summary>
+        /// Get a specific file by an Id
+        /// </summary>
+        /// <param name="fileId">The Id of the file to be returned</param>
+        /// <returns>A file (image)</returns>
+        /// <response code="200">The file (image) with the requested Id</response>
         [HttpGet("{fileId}")]
-        [ApiVersion(0.1, Deprecated = true)]
-        public ActionResult<IEnumerable<PointOfInterestDto>> GetFile(int fileId)
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public IActionResult GetFile(int fileId)
         {
             try
             {
@@ -64,7 +75,16 @@ namespace CityInfo.API.Controllers
             }
         }
 
+        /// <summary>
+        /// Uploads a new file into the server
+        /// </summary>
+        /// <param name="file">The new file to be uploaded</param>
+        /// <returns>A confirmation 200 Status message that the upload was successful</returns>
+        /// <response code="200">A confirmation message that the new file was successfully uploaded</response>
         [HttpPost]
+        [ApiVersion(0.1, Deprecated = true)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult> CreateFile(IFormFile file)
         {
             try

--- a/CityInfo/CityInfo.API/Controllers/FilesController.cs
+++ b/CityInfo/CityInfo.API/Controllers/FilesController.cs
@@ -1,4 +1,5 @@
-﻿using CityInfo.API.Models;
+﻿using Asp.Versioning;
+using CityInfo.API.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
@@ -6,7 +7,7 @@ using Microsoft.AspNetCore.StaticFiles;
 namespace CityInfo.API.Controllers
 {
     [ApiController]
-    [Authorize]
+    //[Authorize]
     [Route("api/[controller]")]
     public class FilesController : ControllerBase
     {
@@ -27,6 +28,7 @@ namespace CityInfo.API.Controllers
         }
 
         [HttpGet("{fileId}")]
+        [ApiVersion(0.1, Deprecated = true)]
         public ActionResult<IEnumerable<PointOfInterestDto>> GetFile(int fileId)
         {
             try

--- a/CityInfo/CityInfo.API/Controllers/PointsOfInterestController.cs
+++ b/CityInfo/CityInfo.API/Controllers/PointsOfInterestController.cs
@@ -10,7 +10,7 @@ namespace CityInfo.API.Controllers
 {
     [ApiController]
     //[Authorize(Policy = "MustBeFromAthens")]
-    [Route("api/cities/{cityId}/[controller]")]
+    [Route("api/v{version:apiVersion}/cities/{cityId}/[controller]")]
     [ApiVersion(2)]
     public class PointsOfInterestController : ControllerBase
     {

--- a/CityInfo/CityInfo.API/Controllers/PointsOfInterestController.cs
+++ b/CityInfo/CityInfo.API/Controllers/PointsOfInterestController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace CityInfo.API.Controllers
 {
     [ApiController]
-    //[Authorize(Policy = "MustBeFromAthens")]
+    [Authorize(Policy = "MustBeFromAthens")]
     [Route("api/v{version:apiVersion}/cities/{cityId}/[controller]")]
     [ApiVersion(2)]
     public class PointsOfInterestController : ControllerBase

--- a/CityInfo/CityInfo.API/Controllers/PointsOfInterestController.cs
+++ b/CityInfo/CityInfo.API/Controllers/PointsOfInterestController.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+﻿using Asp.Versioning;
+using AutoMapper;
 using CityInfo.API.Models;
 using CityInfo.API.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -8,8 +9,9 @@ using Microsoft.AspNetCore.Mvc;
 namespace CityInfo.API.Controllers
 {
     [ApiController]
-    [Authorize(Policy = "MustBeFromAthens")]
+    //[Authorize(Policy = "MustBeFromAthens")]
     [Route("api/cities/{cityId}/[controller]")]
+    [ApiVersion(2)]
     public class PointsOfInterestController : ControllerBase
     {
         // Private members

--- a/CityInfo/CityInfo.API/Models/CityDto.cs
+++ b/CityInfo/CityInfo.API/Models/CityDto.cs
@@ -1,11 +1,33 @@
 ﻿namespace CityInfo.API.Models
 {
+    /// <summary>
+    /// A city with its points of interests
+    /// </summary>
     public class CityDto
     {
+        /// <summary>
+        /// The Id of the city
+        /// </summary>
         public int Id { get; set; }
+
+        /// <summary>
+        /// The name of the city
+        /// </summary>
         public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The description of the city
+        /// </summary>
         public string? Description { get; set; } = null;
+
+        /// <summary>
+        /// The total points of interests of the city
+        /// </summary>
         public int NumberOfPointsOfInterest { get { return PointsOfInterest.Count; } }
+
+        /// <summary>
+        /// A list with all the points of interests of the city
+        /// </summary>
         public ICollection<PointOfInterestDto> PointsOfInterest { get; set; } = new List<PointOfInterestDto>();
     }
 }

--- a/CityInfo/CityInfo.API/Models/CityWithoutPointsOfInterestDto.cs
+++ b/CityInfo/CityInfo.API/Models/CityWithoutPointsOfInterestDto.cs
@@ -1,9 +1,23 @@
 ﻿namespace CityInfo.API.Models
 {
+    /// <summary>
+    /// A city without its points of interests
+    /// </summary>
     public class CityWithoutPointsOfInterestDto
     {
+        /// <summary>
+        /// The Id of the city
+        /// </summary>
         public int Id { get; set; }
+
+        /// <summary>
+        /// The name of the city
+        /// </summary>
         public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The description of the city
+        /// </summary>
         public string? Description { get; set; } = null;
     }
 }

--- a/CityInfo/CityInfo.API/Models/PointOfInterestDto.cs
+++ b/CityInfo/CityInfo.API/Models/PointOfInterestDto.cs
@@ -1,9 +1,23 @@
 ﻿namespace CityInfo.API.Models
 {
+    /// <summary>
+    /// A point of interest of a city
+    /// </summary>
     public class PointOfInterestDto
     {
+        /// <summary>
+        /// The Id of the point of interest
+        /// </summary>
         public int Id { get; set; }
+
+        /// <summary>
+        /// The name of the point of interest
+        /// </summary>
         public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The description of the point of interest
+        /// </summary>
         public string? Description { get; set; } = null;
     }
 }

--- a/CityInfo/CityInfo.API/Models/PointOfInterestForCreationDto.cs
+++ b/CityInfo/CityInfo.API/Models/PointOfInterestForCreationDto.cs
@@ -2,12 +2,21 @@
 
 namespace CityInfo.API.Models
 {
+    /// <summary>
+    /// A point of interest of a city (used to create a new one)
+    /// </summary>
     public class PointOfInterestForCreationDto
     {
+        /// <summary>
+        /// The name of the new point of interest
+        /// </summary>
         [Required(ErrorMessage = "You should provide a name value for the new Point of Interest.")]
         [MaxLength(20, ErrorMessage = "The name value of the new Point of Interest shall not exceed the maximum length of 20 characters.")]
         public string Name { get; set; } = string.Empty;
 
+        /// <summary>
+        /// The description of the new point of interest
+        /// </summary>
         [MaxLength(25, ErrorMessage = "The description value of the new Point of Interest shall not exceed the maximum length of 25 characters.")]
         public string? Description { get; set; } = null;
     }

--- a/CityInfo/CityInfo.API/Models/PointOfInterestForUpdatingDto.cs
+++ b/CityInfo/CityInfo.API/Models/PointOfInterestForUpdatingDto.cs
@@ -2,13 +2,22 @@
 
 namespace CityInfo.API.Models
 {
+    /// <summary>
+    /// A point of interest of a city (used to update an existing one)
+    /// </summary>
     public class PointOfInterestForUpdatingDto
     {
-        [Required(ErrorMessage = "You should provide a name value for the new Point of Interest.")]
+        /// <summary>
+        /// The updated name of an existing point of interest
+        /// </summary>
+        [Required(ErrorMessage = "You should provide a name value for the updated Point of Interest.")]
         [MaxLength(20, ErrorMessage = "The name value of the new Point of Interest shall not exceed the maximum length of 20 characters.")]
         public string Name { get; set; } = string.Empty;
 
-        [MaxLength(25, ErrorMessage = "The description value of the new Point of Interest shall not exceed the maximum length of 25 characters.")]
+        /// <summary>
+        /// The updated description of an existing point of interest
+        /// </summary>
+        [MaxLength(25, ErrorMessage = "The description value of the updated Point of Interest shall not exceed the maximum length of 25 characters.")]
         public string? Description { get; set; } = null;
     }
 }

--- a/CityInfo/CityInfo.API/Program.cs
+++ b/CityInfo/CityInfo.API/Program.cs
@@ -101,6 +101,13 @@ builder.Services.AddAuthorization(options =>
     });
 });
 
+builder.Services.AddApiVersioning(setupAction =>
+{
+    setupAction.ReportApiVersions = true;
+    setupAction.AssumeDefaultVersionWhenUnspecified = true;
+    setupAction.DefaultApiVersion = new Asp.Versioning.ApiVersion(1, 0);
+}).AddMvc();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline (middleware pipeline).

--- a/Postman/ASP.NET-Project.postman_collection.json
+++ b/Postman/ASP.NET-Project.postman_collection.json
@@ -1204,6 +1204,172 @@
 			]
 		},
 		{
+			"name": "Get Point of Interest (get the 1st point of interest of the 1st city from database by requesting specific version 2 of API via query parameter)",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://localhost:{{portNumber}}/api/cities/1/pointsofinterest/1?api-version=2",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "{{portNumber}}",
+					"path": [
+						"api",
+						"cities",
+						"1",
+						"pointsofinterest",
+						"1"
+					],
+					"query": [
+						{
+							"key": "api-version",
+							"value": "2"
+						}
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "https://localhost:{{portNumber}}/api/cities/1/pointsofinterest/1?api-version=2",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://localhost:{{portNumber}}/api/cities/1/pointsofinterest/1?api-version=2",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{portNumber}}",
+							"path": [
+								"api",
+								"cities",
+								"1",
+								"pointsofinterest",
+								"1"
+							],
+							"query": [
+								{
+									"key": "api-version",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Length",
+							"value": "63"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8"
+						},
+						{
+							"key": "Date",
+							"value": "Fri, 09 May 2025 12:16:03 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "Kestrel"
+						},
+						{
+							"key": "api-supported-versions",
+							"value": "2.0"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": 1,\n    \"name\": \"Partially upd - Park\",\n    \"description\": \"Big park\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Get Point of Interest (get the 1st point of interest of the 1st city from database by requesting specific version 2 of API with versioned route)",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://localhost:{{portNumber}}/api/v2.0/cities/1/pointsofinterest/1",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "{{portNumber}}",
+					"path": [
+						"api",
+						"v2.0",
+						"cities",
+						"1",
+						"pointsofinterest",
+						"1"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "https://localhost:{{portNumber}}/api/v2.0/cities/1/pointsofinterest/1",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://localhost:{{portNumber}}/api/v2.0/cities/1/pointsofinterest/1",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{portNumber}}",
+							"path": [
+								"api",
+								"v2.0",
+								"cities",
+								"1",
+								"pointsofinterest",
+								"1"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Length",
+							"value": "63"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8"
+						},
+						{
+							"key": "Date",
+							"value": "Fri, 09 May 2025 12:29:55 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "Kestrel"
+						},
+						{
+							"key": "api-supported-versions",
+							"value": "2.0"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": 1,\n    \"name\": \"Partially upd - Park\",\n    \"description\": \"Big park\"\n}"
+				}
+			]
+		},
+		{
 			"name": "Get File (get the file with id 2 from the datastore)",
 			"request": {
 				"auth": {
@@ -1220,6 +1386,61 @@
 					"port": "{{portNumber}}",
 					"path": [
 						"api",
+						"files",
+						"2"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get File (get the file with id 2 from the datastore by requesting specific deprecated version 0.1 of API via query parameter)",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://localhost:{{portNumber}}/api/files/2?api-version=0.1",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "{{portNumber}}",
+					"path": [
+						"api",
+						"files",
+						"2"
+					],
+					"query": [
+						{
+							"key": "api-version",
+							"value": "0.1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get File (get the file with id 2 from the datastore by requesting specific deprecated version 0.1 of API with versioned route)",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "https://localhost:{{portNumber}}/api/v0.1/files/2",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "{{portNumber}}",
+					"path": [
+						"api",
+						"v0.1",
 						"files",
 						"2"
 					]
@@ -1578,6 +1799,89 @@
 					],
 					"cookie": [],
 					"body": "The file has been uploaded successfully"
+				}
+			]
+		},
+		{
+			"name": "Post Authentication info the get back a token",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"username\": \"Agleoras\",\r\n    \"password\": \"this is a random password\"   \r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://localhost:{{portNumber}}/api/authentication/authenticate",
+					"protocol": "https",
+					"host": [
+						"localhost"
+					],
+					"port": "{{portNumber}}",
+					"path": [
+						"api",
+						"authentication",
+						"authenticate"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Post Authentication info the get back a token",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"username\": \"Agleoras\",\r\n    \"password\": \"this is a random password\"   \r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://localhost:{{portNumber}}/api/authentication/authenticate",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{portNumber}}",
+							"path": [
+								"api",
+								"authentication",
+								"authenticate"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "plain",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "text/plain; charset=utf-8"
+						},
+						{
+							"key": "Date",
+							"value": "Sun, 04 May 2025 17:48:11 GMT"
+						},
+						{
+							"key": "Server",
+							"value": "Kestrel"
+						},
+						{
+							"key": "Transfer-Encoding",
+							"value": "chunked"
+						}
+					],
+					"cookie": [],
+					"body": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiZ2l2ZW5fbmFtZSI6IkFnaXMiLCJmYW1pbHlfbmFtZSI6IlN1cm5hbWUiLCJjaXR5IjoiQnJ1c3NlbHMiLCJuYmYiOjE3NDYzODA4OTEsImV4cCI6MTc0NjM4NDQ5MSwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6NzAzMCIsImF1ZCI6ImNpdHlpbmZvYXBpIn0.ZC-iUNBive0KVpVwQed1vqC9NRSgDho6vACUVmGn6Is"
 				}
 			]
 		},


### PR DESCRIPTION
- Install NuGet package "Asp.Versioning.Mvc" to use for versioning the API
- Add in the service container with the heelp of "AddApiVersioning()"  the versioning service and define as default API version the v1.0
- Apply multiple API versions (1.0 and 2.0) in Cities & Files controller and one API version 2.0 in Points Of Interest controller and use deprecated API version 0.1 in a specific action of Files controller
- Add support for versioned routes (API version as part of the routing instead of HTTP request parameter)
- Modify the properties of the "CityInfo.API" project to generate an XML documentation file out of the comments in the code
- Configure the Swagger UI so that it uses that generated file comments and use and present them in Swagger UI endpoint documentation
- Add documentation in all Files, Cities, Authentication controllers actions (description for the actions and each input argument, what is expected to be returned and the possible Response Types that can be returned, with a short description for the 200 OK response type)
- Add documentation in all DTO classes
- Install "Asp.Versioning.Mvc.ApiExplorer" nuget package to use for the versioning of the API, so that we can substitute the API version in the URL in the documentation
- Use the "Asp.Versioning.Mvc.ApiExplorer" so that we define the swagger endpoints presented in the Swagger UI, for every version of the API
- Leave only undocumented the Point of Interest controller
- Add new OpenAPI security definition in the Swagger UI documentation, that allows to use a specific API bearer token for each request, once generated
- Update Postman commands collection